### PR TITLE
tiogapass: devicetree pruning

### DIFF
--- a/meta-facebook/meta-tiogapass/conf/machine/tiogapass.conf
+++ b/meta-facebook/meta-tiogapass/conf/machine/tiogapass.conf
@@ -1,5 +1,5 @@
 KMACHINE = "aspeed"
-KERNEL_DEVICETREE = "${KMACHINE}-bmc-facebook-${MACHINE}.dtb"
+KERNEL_DEVICETREE = "${KMACHINE}-bmc-facebook-${MACHINE}-pruned.dtb"
 
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-aspeed-sdk"
 PREFERRED_PROVIDER_u-boot = "u-boot-aspeed-sdk"

--- a/meta-facebook/meta-tiogapass/recipes-kernel/linux/linux-aspeed/aspeed-bmc-facebook-tiogapass-pruned.dts
+++ b/meta-facebook/meta-tiogapass/recipes-kernel/linux/linux-aspeed/aspeed-bmc-facebook-tiogapass-pruned.dts
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: GPL-2.0+
+// Copyright (c) 2018 Facebook Inc.
+// Author: Vijay Khemka <vijaykhemka@fb.com>
+/dts-v1/;
+
+#include "aspeed-g5.dtsi"
+#include <dt-bindings/gpio/aspeed-gpio.h>
+#include <dt-bindings/i2c/i2c.h>
+
+/ {
+	model = "Facebook TiogaPass BMC";
+	compatible = "facebook,tiogapass-bmc", "aspeed,ast2500";
+	aliases {
+		serial0 = &uart1;
+		serial4 = &uart5;
+	};
+	chosen {
+		stdout-path = &uart5;
+		bootargs = "console=ttyS4,115200 earlycon";
+	};
+
+	memory@80000000 {
+		reg = <0x80000000 0x20000000>;
+	};
+
+	iio-hwmon {
+		compatible = "iio-hwmon";
+		io-channels = <&adc 0>, <&adc 1>, <&adc 2>, <&adc 3>,
+			      <&adc 4>, <&adc 5>, <&adc 6>, <&adc 7>;
+	};
+
+};
+
+&fmc {
+	status = "okay";
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+#include "openbmc-flash-layout.dtsi"
+	};
+};
+
+&spi1 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_spi1_default>;
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "pnor";
+	};
+};
+
+&lpc_snoop {
+	status = "okay";
+	snoop-ports = <0x80>;
+};
+
+&lpc_ctrl {
+	// Enable lpc clock
+	status = "okay";
+};
+
+&uart1 {
+	// Host Console
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_txd1_default
+		     &pinctrl_rxd1_default>;
+};
+
+&uart2 {
+	// SoL Host Console
+	status = "okay";
+};
+
+&uart3 {
+	// SoL BMC Console
+	status = "okay";
+};
+
+&uart5 {
+	// BMC Console
+	status = "okay";
+};
+
+&kcs2 {
+	// BMC KCS channel 2
+	status = "okay";
+	aspeed,lpc-io-reg = <0xca8>;
+};
+
+&kcs3 {
+	// BMC KCS channel 3
+	status = "okay";
+	aspeed,lpc-io-reg = <0xca2>;
+};
+
+&gpio {
+	status = "okay";
+	gpio-line-names =
+	/*A0-A7*/	"BMC_CPLD_FPGA_SEL",
+			"FM_CPLD_BMC_PWRDN_N",
+			"TP_BMC_GPIOA2",
+			"FM_BMC_SYS_THROTTLE_R_N",
+			"SMB_OCP_FRU_STBY_LVC3_SCL_R",
+			"SMB_OCP_FRU_STBY_LVC3_SDA_R",
+			"FM_BB_BMC_MP_GPIO",
+			"FM_BMC_CPLD_MP_RST_N",
+	/*B0-B7*/	"PWRGD_PCH_PWROK",
+			"BMC_DEBUG_EN",
+			"FM_MP_PS_FAIL_N",
+			"H_CPU0_FAST_WAKE_LVT3_N",
+			"CLK_48M_USB_BMC_R",
+			"BMC_PPIN",
+			"PS_PWROK",
+			"IRQ_PVDDQ_GHJ_VRHOT_LVT3",
+	/*C0-C7*/	"SMB_DEBUG_STBY_LVC3_SCL_R",
+			"SMB_DEBUG_STBY_LVC3_SDA_R",
+			"SMB_PEHPCPU0_STBY_LVC3_SCL",
+			"SMB_PEHPCPU0_STBY_LVC3_SDA",
+			"SMB_PEHPCPU1_STBY_LVC3_SCL",
+			"SMB_PEHPCPU1_STBY_LVC3_SDA",
+			"SMB_PEHPCPU0_STBY_LVC3_R2_SCL",
+			"SMB_PEHPCPU0_STBY_LVC3_R2_SDA",
+	/*D0-D7*/	"BIOS_MRC_DEBUG_MSG_DIS",
+			"BOARD_REV_ID0",
+			"FM_SOL_UART_CH_SEL",
+			"BOARD_REV_ID1",
+			"IRQ_DIMM_SAVE_LVT3",
+			"BOARD_REV_ID2",
+			"CPU_ERR0_LVT3_BMC",
+			"CPU_ERR1_LVT3_BMC",
+	/*E0-E7*/	"RESET_BUTTON",
+			"RESET_OUT",
+			"POWER_BUTTON",
+			"POWER_OUT",
+			"NMI_BUTTON",
+			"IRQ_BMC_PCH_NMI_STBY_N",
+			"CPU0_PROCHOT_LVT3_ BMC",
+			"CPU1_PROCHOT_LVT3_ BMC",
+	/*F0-F7*/	"IRQ_PVDDQ_ABC_VRHOT_LVT3",
+			"SPI_BMC_BT_WP0_N",
+			"IRQ_PVCCIN_CPU0_VRHOT_LVC3",
+			"IRQ_PVCCIN_CPU1_VRHOT_LVC3",
+			"IRQ_PVDDQ_KLM_VRHOT_LVT3",
+			"FM_OCP_MEZZB_PRES_LVT3_BMC",
+			"P3VBAT_BRIDGE_EN",
+			"FM_OCP_MEZZC_PRES_LVT3_BMC",
+	/*G0-G7*/	"CPU_ERR2_LVT3",
+			"CPU_CATERR_LVT3",
+			"PCH_BMC_THERMTRIP",
+			"CPU0_SKTOCC_LVT3",
+			"RQ_PCH_NIC_ALERT_N",
+			"IRQ_OOB_MGMT_RISER_ALERT_N",
+			"IRQ_MEZZ_LAN_ALERT_N",
+			"BIOS_SMI_ACTIVE",
+	/*H0-H7*/	"LED_POST_CODE_0",
+			"LED_POST_CODE_1",
+			"LED_POST_CODE_2",
+			"LED_POST_CODE_3",
+			"LED_POST_CODE_4",
+			"LED_POST_CODE_5",
+			"LED_POST_CODE_6",
+			"LED_POST_CODE_7",
+	/*I0-I7*/	"CPU0_FIVR_FAULT_LVT3",
+			"CPU1_FIVR_FAULT_LVT3",
+			"FORCE_ADR",
+			"UV_ADR_TRIGGER_EN",
+			"SPI_BMC_CS0_N",
+			"SPI_BMC_CLK",
+			"SPI_BMC_DO",
+			"SPI_BMC_DI",
+	/*J0-J7*/	"SGPIO_BMC_CLK_R",
+			"SGPIO_BMC_LD_R_N",
+			"SGPIO_BMC_DOUT_R",
+			"SGPIO_BMC_DIN",
+			"BMC_VGA_HSYNC",
+			"BMC_VGA_VSYNC",
+			"I2C_BMC_VGA_DDC_SCL",
+			"I2C_BMC_VGA_DDC_SDA",
+	/*K0-K7*/	"SMB_SMLINK0_STBY_LVC3_SCL_R",
+			"SMB_SMLINK0_STBY_LVC3_SDA_R",
+			"SMB_VR_STBY_LVC3_SCL_R",
+			"SMB_VR_STBY_LVC3_SDA_R",
+			"SMB_SENSOR_BMC_STBY_LVC3_SCL",
+			"SMB_SENSOR_BMC_STBY_LVC3_SDA",
+			"SMB_BMC_PMBUS_STBY_LVC3_SCL_R",
+			"SMB_BMC_PMBUS_STBY_LVC3_SDA_R",
+	/*L0-L7*/	"IRQ_UV_DETECT",
+			"IRQ_OC_DETECT",
+			"HSC_TIMER_EXP",
+			"FM_BIOS_TOP_SWAP",
+			"MEM_THERM_EVENT_PCH",
+			"PMBUS_ALERT_BUF_EN",
+			"SP1_BMC_HOST_UART_TX",
+			"SP1_BMC_HOST_UART_RX",
+	/*M0-M7*/	"CPU0_RC_ERROR",
+			"CPU1_RC_ERROR",
+			"IRQ_BOARD_BMC_ALERT_N",
+			"OC_DETECT_EN",
+			"CPU0_THERMTRIP_LATCH_LVT3",
+			"CPU1_THERMTRIP_LATCH_LVT3",
+			"SP2_BMC_CM_UART_TX",
+			"SP2_BMC_CM_UART_RX",
+	/*N0-N7*/	"FAN_PWM_OUT_SYS0",
+			"FAN_PWM_OUT_SYS1",
+			"FM_BIOS_PREFRB2_GOOD",
+			"CPU_MSMI_LVT3",
+			"FM_BACKUP_BIOS_SEL_N",
+			"BIOS_SPI_BMC_CTRL",
+			"PUMP_PWM_OUT",
+			"FM_PWRBRK_N",
+	/*O0-O7*/	"FAN_TACH0",
+			"FAN_TACH1",
+			"FAN_TACH2",
+			"FAN_TACH3",
+			"PUMP_TACH0",
+			"PUMP_TACH1",
+			"FM_XRC_PRESENT_N",
+			"FM_XRC_READY_N",
+	/*P0-P7*/	"BOARD_SKU_ID0",
+			"BOARD_SKU_ID1",
+			"BOARD_SKU_ID2",
+			"BOARD_SKU_ID3",
+			"BOARD_SKU_ID4",
+			"BMC_PREQ",
+			"BMC_PWR_DEBUG",
+			"RST_RSMRST",
+	/*Q0-Q7*/	"SMB_OCP_LAN_STBY_LVC3_SCL_R",
+			"SMB_OCP_LAN_STBY_LVC3_SDA_R",
+			"SMB_HOST_STBY_LVC3_SCL_R",
+			"SMB_HOST_STBY_LVC3_SDA_R",
+			"UARTSW_LSB",
+			"UARTSW_MSB",
+			"POST_CARD_PRES_BMC",
+			"PE_BMC_WAKE",
+	/*R0-R7*/	"SPI_BMC_BT_CS_R_N",
+			"FM_MP_PS_REDUNDANT_LOST_N",
+			"BMC_TCK_MUX_SEL",
+			"BMC_PRDY",
+			"BMC_XDP_PRSNT_IN",
+			"RST_BMC_PLTRST_BUF",
+			"SLT_CFG0",
+			"SLT_CFG1",
+	/*S0-S7*/	"THROTTLE",
+			"BMC_READY",
+			"IRQ_SML0_ALERT_N",
+			"HSC_SMBUS_SWITCH_EN",
+			"BMC_STRAP_BIT3",
+			"", // not connected
+			"BMC_STRAP_BIT5",
+			"GPIOS7", // literally
+	/*T0-T7*/	"", // not connected
+			"RMII_BMC_OCP_TXEN_R",
+			"RMII_BMC_OCP_TXD0_R",
+			"RMII_BMC_OCP_TXD1_R",
+			"TP_RGMII1TXD2_GPIOT4",
+			"TP_RGMII1TXD3_GPIOT5",
+			"", // not connected
+			"RMII_BMC_SPRNGVLLE_TXEN_R",
+	/*U0-U7*/	"RMII_BMC_PCH_SPRNGVLLE_TXD0_R",
+			"RMII_BMC_PCH_SPRNGVLLE_TXD1_R",
+			"TP_RGMII2TXD2_GPIOU2",
+			"TP_RGMII2TXD3_GPIOU3",
+			"CLK_50M_CKMNG_BMC_1",
+			"BMC_FAULT",
+			"RMII_BMC_OCP_RXD0",
+			"RMII_BMC_OCP_RXD1",
+	/*V0-V7*/	"RMII_BMC_OCP_CRSDV",
+			"RMII_BMC_OCP_RXER",
+			"CLK_50M_CKMNG_BMC_2",
+			"FAST_PROCHOT_EN",
+			"RMII_SPRNGVLLE_BMC_PCH_RXD0",
+			"RMII_SPRNGVLLE_BMC_PCH_RXD1",
+			"RMII_BMC_PCH_SPRNGVLLE_CRSDV",
+			"RMII_BMC_PCH_SPRNGVLLE_RXER",
+	/*W0-W7*/	"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+	/*X0-X7*/	"",
+			"",
+			"",
+			"GLOBAL_RST_WARN",
+			"CPU0_MEMABC_MEMHOT_LVT3_BMC",
+			"CPU0_MEMDEF_MEMHOT_LVT3_BMC",
+			"CPU1_MEMGHJ_MEMHOT_LVT3_BMC",
+			"CPU1_MEMKLM_MEMHOT_LVT3_BMC",
+	/*Y0-Y7*/	"SIO_S3",
+			"SIO_S5",
+			"BMC_JTAG_SEL",
+			"SIO_ONCONTROL",
+			"SMB_LAN_STBY_LVC3_SCL_R",
+			"SMB_LAN_STBY_LVC3_SDA_R",
+			"SMB_SLOTX24_STBY_LVC3_SCL_R",
+			"SMB_SLOTX24_STBY_LVC3_SDA_R",
+	/*Z0-Z7*/	"FM_BMC_CPLD_GPO",
+			"SIO_POWER_GOOD",
+			"IRQ_PVDDQ_DEF_VRHOT_LVT3",
+			"IRQ_BMC_PCH_SCI_LPC_N",
+			"BMC_STRAP_BIT17",
+			"BMC_STRAP_BIT18",
+			"BMC_STRAP_BIT20",
+			"BMC_STRAP_BIT27",
+	/*AA0-AA7*/	"CPU1_SKTOCC_LVT3",
+			"IRQ_SML1_PMBUS_ALERT",
+			"SERVER_POWER_LED",
+			"FM_TPM_PRES_N",
+			"PECI_MUX_SELECT",
+			"UV_HIGH_SET",
+			"IRQ_LOM_ALERT_N",
+			"POST_COMPLETE",
+	/*AB0-AB7*/	"IRQ_HSC_FAULT",
+			"OCP_MEZZA_PRES",
+			"BMC_SELF_HW_RST",
+			"", // not connected
+			"", // not connected
+			"", // not connected
+			"", // not connected
+			"", // not connected
+	/*AC0-AC7*/	"LPC_LAD0_IO0_R",
+			"LPC_LAD1_IO1_R",
+			"LPC_LAD2_IO2_R",
+			"LPC_LAD3_IO3_R",
+			"CLK_24M_BMC_LPC",
+			"LPC_LFRAME_N_CS0_R_N",
+			"IRQ_LPC_SERIRQ_R",
+			"RST_BMC_LVC3_N";
+};
+
+&mac0 { // OCP Mezz NIC
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_rmii1_default>;
+	clocks = <&syscon ASPEED_CLK_GATE_MAC1CLK>,
+		 <&syscon ASPEED_CLK_MAC1RCLK>;
+	clock-names = "MACCLK", "RCLK";
+	use-ncsi;
+};
+
+&adc {
+	status = "okay";
+};
+
+&i2c0 {
+	status = "okay";
+	multi-master;
+	//TODO: CPU0 PIROM at 0x50
+	//TODO: CPU1 PIROM at 0x51
+};
+
+&i2c1 {
+	status = "okay";
+	multi-master;
+	//TODO
+	//upstream .dts says there is an nxp,pca9544 at 0x71
+	//but it does not appear for me even with host powered on.
+};
+&i2c2 {
+	status = "okay";
+	multi-master;
+	//TODO at 0x10
+	//TODO at 0x16
+	//TODO at 0x70
+};
+
+&i2c3 {
+	status = "okay";
+	multi-master;
+	//TODO at 0x08
+	//TODO at 0x44
+	//TODO at 0x51 (should be eeprom, but driver does not work?)
+	//TODO at 0x68 ICS9FGP204
+	//TODO at 0x6c NB3W1200L (only when host is powered on)
+};
+&i2c4 {
+	status = "okay";
+	multi-master;
+	// BMC Debug Header
+	ipmb0@10 {
+		compatible = "ipmb-dev";
+		reg = <(0x10 | I2C_OWN_SLAVE_ADDRESS)>;
+		i2c-protocol;
+	};
+	//TODO at 0x16
+	//TODO at 0x70
+	//springville smb should be here
+};
+
+&i2c5 {
+	status = "okay";
+	multi-master;
+	// turning host off/on does not change anything here
+	//compared to upstream dt we are missing some...
+
+	regulator@0x48 { //pxe1610C
+		compatible = "infineon,pxe1610";
+		register = <0x48>;
+	};
+	regulator@0x4a { //pxe1110C
+		compatible = "infineon,pxe1610";
+		register = <0x4a>;
+	};
+	regulator@0x68 { //pxe1110C
+		compatible = "infineon,pxe1610";
+		register = <0x68>;
+	};
+	regulator@0x70 { //pxm1310C
+		compatible = "infineon,pxe1610";
+		register = <0x70>;
+	};
+	regulator@0x72 { //pxm1310C
+		compatible = "infineon,pxe1610";
+		register = <0x72>;
+	};
+};
+
+//TODO: continue here later...
+
+&i2c6 {
+	status = "okay";
+	multi-master;
+};
+
+&i2c7 {
+	status = "okay";
+	multi-master;
+};
+
+&i2c8 {
+	status = "okay";
+	multi-master;
+};
+
+&i2c9 {
+	status = "okay";
+	multi-master;
+	//USB Debug Connector
+	ipmb0@10 {
+		compatible = "ipmb-dev";
+		reg = <(0x10 | I2C_OWN_SLAVE_ADDRESS)>;
+		i2c-protocol;
+	};
+
+	// probably the below are due to the debug card being attached
+	//TODO 0x27
+	//TODO 0x54
+};
+
+&pwm_tacho {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_pwm0_default
+                     &pinctrl_pwm1_default>;
+	fan@0 {
+		reg = <0x00>;
+		aspeed,fan-tach-ch = /bits/ 8 <0x00>;
+	};
+	fan@1 {
+		reg = <0x01>;
+		aspeed,fan-tach-ch = /bits/ 8 <0x01>;
+	};
+};

--- a/meta-facebook/meta-tiogapass/recipes-kernel/linux/linux-aspeed_%.bbappend
+++ b/meta-facebook/meta-tiogapass/recipes-kernel/linux/linux-aspeed_%.bbappend
@@ -1,2 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-aspeed:"
+
+SRC_URI:append = "\
+file://aspeed-bmc-facebook-tiogapass-pruned.dts;subdir=git/arch/${ARCH}/boot/dts \
+"
+
 SRC_URI += "file://tiogapass.cfg"


### PR DESCRIPTION
- our tiogapass gets its own devicetree, which we can change without .patch files

- enter all the gpios from the schematics. Even if they are missing on our variant, better to know what should have been connected there.

- remove stuff from devicetree which is causing errors in our kernel logs.

- remove the missing bmc dedicated NIC


please review for any mistakes on inconsistencies :) 

